### PR TITLE
fix: correct invalid Docker Compose port mapping in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ services:
     container_name: microwarp
     restart: always
     ports:
-      - "127.0.0.11080:1080" # 标准的无密码 SOCKS5 端口，仅监听本机
+      - "127.0.0.1:1080:1080" # 标准的无密码 SOCKS5 端口，仅监听本机
     cap_add:
       - NET_ADMIN
       - SYS_MODULE


### PR DESCRIPTION
This fixes the Chinese `docker-compose.yml` example in `README.md`.

The previous port mapping was:

```yaml
- "127.0.0.11080:1080"
```

That format is invalid for Docker Compose and triggers:

```text
invalid hostPort: 127.0.0.10880
```

It is now corrected to:

```yaml
- "127.0.0.1:1080:1080"
```