### PR TITLE
修复：保留 Tailscale 回程路由，避免 SOCKS5 发布后连接卡死

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,8 +91,21 @@ fi
 # ==========================================
 # 3. 拉起内核网卡
 # ==========================================
+# 在启用 WARP 前记录 100.64.0.0/10 的原始回程路径，避免发布端口后 Tailscale 客户端握手卡死
+PRE_WARP_ROUTE=$(ip route get 100.64.0.1 2>/dev/null | head -n 1 || true)
+PRE_WARP_GW=$(printf '%s\n' "$PRE_WARP_ROUTE" | awk '{for (i = 1; i <= NF; i++) if ($i == "via") print $(i + 1)}')
+PRE_WARP_DEV=$(printf '%s\n' "$PRE_WARP_ROUTE" | awk '{for (i = 1; i <= NF; i++) if ($i == "dev") print $(i + 1)}')
+
 echo "==> [MicroWARP] 正在启动 Linux 内核级 wg0 网卡..."
 wg-quick up wg0 > /dev/null 2>&1
+
+# 仅在 WARP 启动前确实存在原始回程路径时恢复 100.64.0.0/10，减少对非 Tailscale 场景的影响
+TAILSCALE_CIDR=${TAILSCALE_CIDR:-"100.64.0.0/10"}
+if [ -n "$PRE_WARP_GW" ] && [ -n "$PRE_WARP_DEV" ]; then
+    if ip route replace "$TAILSCALE_CIDR" via "$PRE_WARP_GW" dev "$PRE_WARP_DEV" > /dev/null 2>&1; then
+        echo "==> [MicroWARP] 已为 ${TAILSCALE_CIDR} 恢复 WARP 启动前的回程路由: via ${PRE_WARP_GW} dev ${PRE_WARP_DEV}"
+    fi
+fi
 
 echo "==> [MicroWARP] 当前出口 IP 已成功变更为："
 # 获取最新的 CF 溯源 IP (加入 5 秒强制超时，完美替代有缺陷的 & 后台执行)


### PR DESCRIPTION
## 问题
当容器把 SOCKS5 端口发布到宿主机后，如果从其他 Tailscale 节点访问该端口，请求可以进入容器，但回包会被错误地送进 WARP 的 `wg0`，而不是通过宿主机原有网络路径返回。

这会导致 TCP 握手卡住，表现为：
- `microsocks` 已经监听在 `0.0.0.0:1080`
- Docker 端口映射也正常
- 但从 Tailscale 对等节点访问时连接超时

## 原因
`wg-quick up wg0` 会安装默认路由，覆盖容器在 WARP 启动前对 `100.64.0.0/10` 的原始回程路径，导致这部分流量被错误地送到 `wg0`。

## 修复
在 `wg-quick up wg0` 之前：
- 先探测 `100.64.0.0/10` 在容器中的原始出口路径

在 `wg-quick up wg0` 之后：
- 仅当原始路径确实存在时，才为 `100.64.0.0/10` 恢复这条回程路由

这样可以避免直接假设 Docker 默认网关，减少对非 Tailscale 场景的影响。

## 验证
已在实际环境验证：
- 修改前：从另一台 Tailscale 节点访问 SOCKS5 端口会超时
- 修改后：可以通过该 SOCKS5 端口正常完成请求，并保持 WARP 出口