### PR TITLE
Add ALLOW_NO_AUTH fail-safe guard for unauthenticated SOCKS startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Run the container:
 docker compose up -d
 ```
 
+> **Fail-safe defaults**: the sample mapping publishes only on host loopback (`127.0.0.1:1080:1080`), so the proxy is never exposed publicly. Starting without `SOCKS_USER`/`SOCKS_PASS` is refused unless you explicitly set `ALLOW_NO_AUTH=1`.
+
 ### ⚙️ Environment Variables
 
 | Variable | Default | Description |
@@ -100,7 +102,8 @@ docker compose up -d
 | **`TUNNEL_PROTOCOL`** | `wireguard` | `wireguard` (kernel, default) or `masque` (usque). Aliases: `wg` / `usque`. |
 | `BIND_ADDR` | `0.0.0.0` | SOCKS5 listen address. Use `::` for IPv6 / dual-stack listen. |
 | `BIND_PORT` | `1080` | SOCKS5 listen port. |
-| `SOCKS_USER` / `SOCKS_PASS` | *(empty)* | Optional SOCKS5 authentication. Both must be set. |
+| `SOCKS_USER` / `SOCKS_PASS` | *(empty)* | Optional SOCKS5 authentication. Both must be set together; starting with neither set is refused. |
+| `ALLOW_NO_AUTH` | `0` | Fail-safe opt-in: `1` (or `true`/`yes`/`on`) allows starting without SOCKS credentials (public proxy). |
 | `ENABLE_IPV6` | `1` | `1`/`true` = dual-stack WARP; `0` = IPv4-only. |
 | `MTU` | `1280` | WireGuard interface MTU. |
 | `KEEPALIVE` | `15` | `PersistentKeepalive` seconds (NAT/QoS keep-alive). |
@@ -215,7 +218,7 @@ services:
     container_name: microwarp
     restart: always
     ports:
-      - "127.0.0.1:1080:1080" # 默认无密码 SOCKS5 端口，仅监听本机
+      - "127.0.0.1:1080:1080" # 防呆默认：仅发布到宿主机回环，不暴露公网
     cap_add:
       - NET_ADMIN
       - SYS_MODULE
@@ -236,6 +239,8 @@ volumes:
 docker compose up -d
 ```
 
+> **防呆默认**：示例映射仅发布到宿主机回环（`127.0.0.1:1080:1080`），代理不会暴露公网。未配置 `SOCKS_USER`/`SOCKS_PASS` 时会拒绝启动，除非显式设置 `ALLOW_NO_AUTH=1`。
+
 ### ⚙️ 环境变量一览
 
 | 变量 | 默认值 | 说明 |
@@ -243,7 +248,8 @@ docker compose up -d
 | **`TUNNEL_PROTOCOL`** | `wireguard` | `wireguard`（内核，默认）或 `masque`（usque）。别名：`wg` / `usque` |
 | `BIND_ADDR` | `0.0.0.0` | SOCKS5 监听地址；需要 IPv6 入站时设为 `::` |
 | `BIND_PORT` | `1080` | SOCKS5 监听端口 |
-| `SOCKS_USER` / `SOCKS_PASS` | 空 | 可选认证；需同时设置 |
+| `SOCKS_USER` / `SOCKS_PASS` | 空 | 可选认证；两者必须同时设置。均未设置时拒绝启动 |
+| `ALLOW_NO_AUTH` | `0` | 防呆开关：`1` 显式允许以无认证公开模式启动 |
 | `ENABLE_IPV6` | `1` | `1` 双栈 / `0` 仅 IPv4 |
 | `MTU` | `1280` | WireGuard MTU |
 | `KEEPALIVE` | `15` | UDP 心跳秒数，对抗 NAT/QoS |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     container_name: microwarp
     restart: always
     ports:
+      # Fail-safe default: publish only on the host loopback so an
+      # unauthenticated proxy is never exposed publicly. Only widen this
+      # mapping if you have configured SOCKS_USER/SOCKS_PASS.
       - "127.0.0.1:1080:1080"
     cap_add:
       - NET_ADMIN
@@ -31,6 +34,7 @@ services:
     #   - BIND_PORT=1080              # SOCKS5 listen port
     #   - SOCKS_USER=admin            # optional auth username
     #   - SOCKS_PASS=123456           # optional auth password
+    #   - ALLOW_NO_AUTH=              # 1 = allow starting with no SOCKS auth (public proxy; default 0 refuses)
     #   - ENABLE_IPV6=1               # 1/true = dual-stack WARP (default); 0 = IPv4 only
     #   - MTU=1280                    # WireGuard MTU
     #   - KEEPALIVE=15                # PersistentKeepalive seconds

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,8 @@ WG_IFACE="${WG_IFACE:-wg0}"
 WG_MTU="${MTU:-1280}"
 LISTEN_ADDR="${BIND_ADDR:-0.0.0.0}"
 LISTEN_PORT="${BIND_PORT:-1080}"
+# Fail-safe opt-in required to start without SOCKS credentials
+ALLOW_NO_AUTH="${ALLOW_NO_AUTH:-0}"
 ENABLE_IPV6="${ENABLE_IPV6:-1}"
 TAILSCALE_CIDR="${TAILSCALE_CIDR:-100.64.0.0/10}"
 TAILSCALE_CIDR_V6="${TAILSCALE_CIDR_V6:-fd7a:115c:a1e0::/48}"
@@ -169,6 +171,39 @@ is_truthy() {
     case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
         1|true|yes|on) return 0 ;;
         *) return 1 ;;
+    esac
+}
+
+# ==========================================
+# Fail-safe guard: refuse to launch an unauthenticated public proxy
+# unless ALLOW_NO_AUTH=1 explicitly opts in.
+# Called first in main() so unsafe configs die before any
+# registration / network activity.
+# ==========================================
+check_socks_auth_policy() {
+    auth_user="${SOCKS_USER:-}"
+    auth_pass="${SOCKS_PASS:-}"
+
+    # Both credentials set: normal authenticated mode.
+    if [ -n "$auth_user" ] && [ -n "$auth_pass" ]; then
+        return 0
+    fi
+
+    # Half-configured credentials are always a misconfiguration.
+    if [ -n "$auth_user" ] || [ -n "$auth_pass" ]; then
+        die "SOCKS_USER 与 SOCKS_PASS 必须同时设置；当前仅设置了其中一项"
+    fi
+
+    # No credentials at all: require explicit opt-in.
+    if ! is_truthy "$ALLOW_NO_AUTH"; then
+        die "安全防护：未配置 SOCKS_USER/SOCKS_PASS，拒绝启动无认证代理；如确需公开模式，请显式设置 ALLOW_NO_AUTH=1"
+    fi
+
+    warn "已通过 ALLOW_NO_AUTH=1 显式启用无认证公开模式"
+    case "$LISTEN_ADDR" in
+        0.0.0.0|::|'*')
+            warn "SOCKS 监听 ${LISTEN_ADDR}:${LISTEN_PORT}，请确保宿主机端口映射为 127.0.0.1:1080:1080，避免暴露公网"
+            ;;
     esac
 }
 
@@ -485,7 +520,7 @@ start_socks() {
         log "🔒 身份认证已开启 (User: ${SOCKS_USER})"
         set -- "$@" -u "$SOCKS_USER" -P "$SOCKS_PASS"
     else
-        warn "未设置 SOCKS_USER/SOCKS_PASS，当前为公开访问模式"
+        warn "无认证公开模式 (ALLOW_NO_AUTH=1)，请确保宿主机仅映射 127.0.0.1"
     fi
 
     log "🚀 MicroSOCKS 监听 ${LISTEN_ADDR}:${LISTEN_PORT}"
@@ -595,7 +630,7 @@ start_masque_socks() {
         log "🔒 身份认证已开启 (User: ${SOCKS_USER})"
         set -- "$@" -u "$SOCKS_USER" -w "$SOCKS_PASS"
     else
-        warn "未设置 SOCKS_USER/SOCKS_PASS，当前为公开访问模式"
+        warn "无认证公开模式 (ALLOW_NO_AUTH=1)，请确保宿主机仅映射 127.0.0.1"
     fi
 
     # HTTP/2 (TCP:443) fallback — only on full socks / modes that support it.
@@ -686,6 +721,9 @@ run_masque_path() {
 # Main
 # ==========================================
 main() {
+    # Fail-fast: block unsafe auth configs before any registration / network I/O.
+    check_socks_auth_policy
+
     proto="$(normalize_tunnel_protocol "$TUNNEL_PROTOCOL")"
     log "TUNNEL_PROTOCOL=${proto}"
 


### PR DESCRIPTION
Refuse to launch without SOCKS_USER/SOCKS_PASS unless ALLOW_NO_AUTH=1
is explicitly set; half-configured credentials are also rejected.
Document the loopback-only port mapping default in README and compose.